### PR TITLE
purge package `php5-suhosin` on wheezy systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,12 @@ class php5 {
         require => Package['php5-common'],
       }
     }
-    default: {  }
+    'wheezy': {
+      package {'php5-suhosin':
+        ensure => purged
+      }
+    }
+    default: { }
   }
 
   file { '/etc/php5/conf.d/zzz_common.ini':


### PR DESCRIPTION
In PHP 5.4 and newer, the suhosin is no longer available. To remove errors such as:
```
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20100525/suhosin.so' - /usr/lib/php5/20100525/suhosin.so: cannot open shared object file: No such file or directory in Unknown on line 0`
```
this update will purge the `php5-suhosin` package on wheezy systems, which removes any left over config files for suhosin.