### PR TITLE
change module name to comply with module naming standards

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,4 @@
-name         'bigcommerce-techops-php5'
+name         'bigcommerce-php5'
 version      '0.0.3'
 license      'MIT'
 summary      'Install and manage PHP'


### PR DESCRIPTION
The current name of this module `bigcommerce-techops-php5` doesn't comply with puppet module standards, so librarian-puppet errors out with:
```Unable to parse ~/.tmp/librarian/cache/source/git/8df80a554ef30e0a/Modulefile, ignoring: Invalid 'name' field in metadata.json: the module name contains non-alphanumeric (or underscore) characters```

Renaming this module to `bigcommerce-php5`